### PR TITLE
Fixes for radio and checkbox button when using bootstrap 4.3.1 (Not alpha)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### [0.0.3] - 2019-07-29
+
+### Fixed
+
+* Workaround for checkbox buttons when using latest bootstrap (not alpha): Remove attribute `"aria-pressed"` and class `active` manually to deactivate a checkbox button.
+* Workaround for radio and checkbox buttons when using latest bootstrap (not alpha): Add attribute `"aria-pressed"` and class `active` manually to activate a radio and checkbox button.
+
 ### [0.0.2] - 2017-05-11
 
 #### Added

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "prokki/twbs-toggle-buttons",
-  "description": "A small javascript snippet to use Bootstrap Button Groups (https://v4-alpha.getbootstrap.com/components/button-group/) for toggle buttons.",
+  "description": "A small javascript snippet to use Bootstrap Button Groups (https://getbootstrap.com/components/button-group/) for toggle buttons.",
   "homepage": "https://github.com/prokki/twbs-toggle-buttons",
   "type": "library",
   "keywords": [

--- a/src/js/TwbsToggleButtons.js
+++ b/src/js/TwbsToggleButtons.js
@@ -259,6 +259,18 @@ class TwbsToggleButtons
 		});
 
 		$(button).find(":input").attr("checked", "checked");
+
+		// workaround on radio and checkbox button:
+		// the attribute "aria-pressed" stays on "false" (even if the attribute is changed furthermore),
+		// add the attribute manually with setTimeout() function 
+		if ((this._getInputType() === TwbsToggleButtons.TYPE_RADIO() || this._getInputType() === TwbsToggleButtons.TYPE_CHECKBOX()) && button.getAttribute("aria-pressed") === "false" )
+		{
+			window.setTimeout(function ()
+			{
+				button.classList.remove(TwbsToggleButtons.ACTIVE_CLASS());
+				button.setAttribute("aria-pressed", "true");
+			}, 0);
+		}
 	};
 
 	/**
@@ -285,10 +297,10 @@ class TwbsToggleButtons
 
 		$(button).find(":input").attr("checked", null);
 
-		// workaround on radio button:
-		//   the attribute "aria-pressed" stays on "true" (even if the attribute is changed furthermore),
-		//   remove the attribute manually with setTimeout() function 
-		if ( this._getInputType() === TwbsToggleButtons.TYPE_RADIO() && button.getAttribute("aria-pressed") === "true" )
+		// workaround on radio and checkbox button:
+		// the attribute "aria-pressed" stays on "true" (even if the attribute is changed furthermore),
+		// remove the attribute manually with setTimeout() function 
+		if ((this._getInputType() === TwbsToggleButtons.TYPE_RADIO() || this._getInputType() === TwbsToggleButtons.TYPE_CHECKBOX()) && button.getAttribute("aria-pressed") === "true" )
 		{
 			window.setTimeout(function ()
 			{

--- a/src/js/TwbsToggleButtons.js
+++ b/src/js/TwbsToggleButtons.js
@@ -1,4 +1,4 @@
-/** @preserve Twitter Bootstrap Toogle Buttons 0.0.2
+/** @preserve Twitter Bootstrap Toogle Buttons 0.0.3
  * Available under the MIT license.
  * See https://github.com/prokki/twbs-toggle-buttons for more information.
  */


### PR DESCRIPTION
When using the latest Bootstrap 4.3.1 js, the following radio and checkbox buttons dont toggle to deactivate when they are set to not required.

![image](https://user-images.githubusercontent.com/51349059/62027999-861a1800-b222-11e9-96c3-3ea4bf506b03.png)
![image](https://user-images.githubusercontent.com/51349059/62028008-8e725300-b222-11e9-98dd-6901b2bb4f05.png)
